### PR TITLE
Added JSON-tags to structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 
+## [0.4.0] - 2025-05-21
+
+### Added
+
+- JSON tags to structs
+
 ## [0.3.1] - 2025-05-21
 
 ### Added

--- a/changelog.go
+++ b/changelog.go
@@ -1,6 +1,6 @@
 package verso
 
 type Changelog struct {
-	Path     string
-	Versions []Semver
+	Path     string   `json:"path"`
+	Versions []Semver `json:"versions"`
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,3 @@
 module github.com/hkionline/verso
 
 go 1.24.2
-
-retract (
-	v1.0.0
-	v2.0.0
-)

--- a/semver.go
+++ b/semver.go
@@ -8,12 +8,12 @@ import (
 
 // Semver struct contains semantic version information
 type Semver struct {
-	Major      int
-	Minor      int
-	Patch      int
-	PreRelease string
-	Build      string
-	Date       time.Time
+	Major      int       `json:"major"`
+	Minor      int       `json:"minor"`
+	Patch      int       `json:"patch"`
+	PreRelease string    `json:"preRelease"`
+	Build      string    `json:"build"`
+	Date       time.Time `json:"date"`
 }
 
 // String implements [fmt.Stringer] interface. It returns Semver fields' values as a string.


### PR DESCRIPTION
The PR adds JSON-tags to all of the structs (changelog and semver) and thus closes issue #1.
The PR also removes the retract instructions from go.mod, they are causing issues. The project will soon-ish move to v1.