### PR TITLE
Adds brackets around Semver string output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- First "stable" version
+- First "stable" version of verso library
 - Semantic version output in brackets
 
 ## [0.4.1] - 2025-07-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.0.0] - 2025-08-09
+
+### Changed
+
+- First "stable" version
+- Semantic version output in brackets
+
 ## [0.4.1] - 2025-07-09
 
 ### Changed

--- a/semver.go
+++ b/semver.go
@@ -28,6 +28,7 @@ func (s Semver) String() string {
 	}
 
 	sb := strings.Builder{}
+	sb.WriteString("[")
 	sb.WriteString(fmt.Sprint(s.Major))
 	sb.WriteString(".")
 	sb.WriteString(fmt.Sprint(s.Minor))
@@ -43,6 +44,8 @@ func (s Semver) String() string {
 		sb.WriteString("+")
 		sb.WriteString(fmt.Sprint(s.Build))
 	}
+
+	sb.WriteString("]")
 
 	if !s.Date.IsZero() {
 		sb.WriteString(" ")

--- a/semver_test.go
+++ b/semver_test.go
@@ -26,7 +26,7 @@ func TestSemverString(t *testing.T) {
 				Build:      "002",
 				Date:       time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC),
 			},
-			expected: "1.1.2-beta+002 2023-10-01",
+			expected: "[1.1.2-beta+002] 2023-10-01",
 		},
 		{
 			name: "default Major.Minor.Patch",
@@ -46,7 +46,7 @@ func TestSemverString(t *testing.T) {
 				Build: "002",
 				Date:  time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC),
 			},
-			expected: "1.1.2+002 2023-10-01",
+			expected: "[1.1.2+002] 2023-10-01",
 		},
 		{
 			name: "empty Build field",
@@ -57,7 +57,7 @@ func TestSemverString(t *testing.T) {
 				PreRelease: "beta",
 				Date:       time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC),
 			},
-			expected: "1.1.2-beta 2023-10-01",
+			expected: "[1.1.2-beta] 2023-10-01",
 		},
 		{
 			name: "default Date field",
@@ -69,7 +69,7 @@ func TestSemverString(t *testing.T) {
 				Build:      "002",
 				Date:       time.Time{},
 			},
-			expected: "1.1.2-beta+002",
+			expected: "[1.1.2-beta+002]",
 		},
 	}
 


### PR DESCRIPTION
Resolves issue #11 by adding brackets around the outputted string representation of semver. This format is used by the changelog and is perhaps easier to regex if need be.