### PR TITLE
Fix for the conflicting 1.0.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.0.1] - 2025-08-09
+
+### Added
+
+- New patch to get rid of the haunting old v1.0.0 in pkg.go.dev repositories, please use 1.+ versions instead of just the 1.0.0 version
+
 ## [1.0.0] - 2025-08-09
 
 ### Changed


### PR DESCRIPTION
Verso had once upon a time a v1.0.0 version until its version were rolled back to 0.x versions. Since Go's package repocitories in pkg.go.dev and proxy.golang.org do not allow removing old versions, the old 1.0.0 has been haunting the project ever since. To move past the issue the 1.0.1 is released with this PR and the following v1.0.1 tag.

***Please, do not use version 1.0.0 specifically. Use 1.0.1 and later.***